### PR TITLE
✨ feat: 허브 등록 기능

### DIFF
--- a/core/core-hub-api/build.gradle
+++ b/core/core-hub-api/build.gradle
@@ -11,7 +11,4 @@ dependencies {
     testImplementation project(":tests:api-docs")
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
-
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
 }

--- a/core/core-hub-api/src/docs/asciidoc/index.adoc
+++ b/core/core-hub-api/src/docs/asciidoc/index.adoc
@@ -9,30 +9,24 @@
 
 == Introduce
 
-This is the Core API documentation.
+허브 API는 허브를 등록하고 조회하는 기능을 제공합니다.
 
-== Example API
+= 허브 API
 
-=== Example GET API
-==== Curl Request
-include::{snippets}/exampleGet/curl-request.adoc[]
-==== Path Parameters
-include::{snippets}/exampleGet/path-parameters.adoc[]
-==== Query Parameters
-include::{snippets}/exampleGet/query-parameters.adoc[]
-==== Http Response
-include::{snippets}/exampleGet/http-response.adoc[]
-==== Response Fields
-include::{snippets}/exampleGet/response-fields.adoc[]
+== 허브 등록
 
-'''
+=== Curl Request
 
-=== Example POST API
-==== Curl Request
-include::{snippets}/examplePost/curl-request.adoc[]
-==== Request Fields
-include::{snippets}/examplePost/request-fields.adoc[]
-==== Http Response
-include::{snippets}/examplePost/http-response.adoc[]
-==== Response Fields
-include::{snippets}/examplePost/response-fields.adoc[]
+include::{snippets}/허브 등록/curl-request.adoc[]
+
+=== Http Request
+
+include::{snippets}/허브 등록/http-request.adoc[]
+
+=== Http Response
+
+include::{snippets}/허브 등록/http-response.adoc[]
+
+=== Response Fields
+
+include::{snippets}/허브 등록/response-fields.adoc[]

--- a/core/core-hub-api/src/http/v1/hub.http
+++ b/core/core-hub-api/src/http/v1/hub.http
@@ -1,0 +1,22 @@
+### Local Variable
+@host=http://localhost:19095
+@sequence=1
+@name="서울특별시 센터"
+@city="서울특별시"
+@fullAddress="서울특별시 송파구 송파대로 55"
+@latitude=37.4747005
+@longitude=127.123397
+
+###
+# @name 허브 등록
+POST {{host}}/api/v1/hubs
+Content-Type: application/json
+
+{
+  "sequence": {{sequence}},
+  "name": {{name}},
+  "city": {{city}},
+  "fullAddress": {{fullAddress}},
+  "latitude": {{latitude}},
+  "longitude": {{longitude}}
+}

--- a/core/core-hub-api/src/main/java/com/phoenix/logistics/core/hub/api/controller/v1/HubController.java
+++ b/core/core-hub-api/src/main/java/com/phoenix/logistics/core/hub/api/controller/v1/HubController.java
@@ -1,0 +1,32 @@
+package com.phoenix.logistics.core.hub.api.controller.v1;
+
+import com.phoenix.logistics.core.hub.api.controller.v1.request.HubRegistrationRequest;
+import com.phoenix.logistics.core.hub.api.controller.v1.response.HubRegistrationResponse;
+import com.phoenix.logistics.core.hub.api.support.response.ApiResponse;
+import com.phoenix.logistics.core.hub.domain.HubService;
+import com.phoenix.logistics.core.hub.domain.HubWithUuid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HubController {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private final HubService hubService;
+
+    public HubController(HubService hubService) {
+        this.hubService = hubService;
+    }
+
+    @PostMapping("/api/v1/hubs")
+    public ApiResponse<HubRegistrationResponse> registerHub(@RequestBody HubRegistrationRequest request) {
+        HubWithUuid result = hubService.register(request.toHub());
+        log.info("허브 등록 : {}", result);
+        return ApiResponse.success(HubRegistrationResponse.of(result));
+    }
+
+}

--- a/core/core-hub-api/src/main/java/com/phoenix/logistics/core/hub/api/controller/v1/request/HubRegistrationRequest.java
+++ b/core/core-hub-api/src/main/java/com/phoenix/logistics/core/hub/api/controller/v1/request/HubRegistrationRequest.java
@@ -1,0 +1,11 @@
+package com.phoenix.logistics.core.hub.api.controller.v1.request;
+
+import com.phoenix.logistics.core.hub.domain.Hub;
+
+public record HubRegistrationRequest(int sequence, String name, String city, String fullAddress, double latitude,
+        double longitude) {
+
+    public Hub toHub() {
+        return new Hub(sequence, name, city, fullAddress, latitude, longitude);
+    }
+}

--- a/core/core-hub-api/src/main/java/com/phoenix/logistics/core/hub/api/controller/v1/response/HubRegistrationResponse.java
+++ b/core/core-hub-api/src/main/java/com/phoenix/logistics/core/hub/api/controller/v1/response/HubRegistrationResponse.java
@@ -1,0 +1,11 @@
+package com.phoenix.logistics.core.hub.api.controller.v1.response;
+
+import com.phoenix.logistics.core.hub.domain.HubWithUuid;
+import java.util.UUID;
+
+public record HubRegistrationResponse(UUID hubUuid) {
+
+    public static HubRegistrationResponse of(HubWithUuid hubWithUuid) {
+        return new HubRegistrationResponse(hubWithUuid.hubUuid());
+    }
+}

--- a/core/core-hub-api/src/main/resources/application.yml
+++ b/core/core-hub-api/src/main/resources/application.yml
@@ -16,6 +16,7 @@ server:
     threads:
       max: 600
       min-spare: 100
+  port: 19095
 
 ---
 spring.config.activate.on-profile: local

--- a/core/core-hub-api/src/test/java/com/phoenix/logistics/core/hub/api/controller/v1/HubControllerTest.java
+++ b/core/core-hub-api/src/test/java/com/phoenix/logistics/core/hub/api/controller/v1/HubControllerTest.java
@@ -1,0 +1,77 @@
+package com.phoenix.logistics.core.hub.api.controller.v1;
+
+import static com.phoenix.logistics.test.api.RestDocsUtils.requestPreprocessor;
+import static com.phoenix.logistics.test.api.RestDocsUtils.responsePreprocessor;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.phoenix.logistics.core.hub.api.controller.v1.request.HubRegistrationRequest;
+import com.phoenix.logistics.core.hub.domain.Hub;
+import com.phoenix.logistics.core.hub.domain.HubService;
+import com.phoenix.logistics.core.hub.domain.HubWithUuid;
+import com.phoenix.logistics.test.api.RestDocsTest;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+class HubControllerTest extends RestDocsTest {
+
+    private UUID hubUuid;
+
+    private HubService hubService;
+
+    private HubController hubController;
+
+    @BeforeEach
+    void setUp() {
+        this.hubUuid = UUID.randomUUID();
+
+        hubService = mock(HubService.class);
+        hubController = new HubController(hubService);
+        mockMvc = mockController(hubController);
+    }
+
+    @Test
+    void 허브_등록() throws JsonProcessingException {
+        // given
+        int sequence = 1;
+        String name = "서울특별시 센터";
+        String city = "서울특별시";
+        String fullAddress = "서울특별시 송파구 송파대로 55";
+        double latitude = 37.4747005;
+        double longitude = 127.123397;
+        HubWithUuid hubWithUuid = new HubWithUuid(hubUuid, sequence, name, city, fullAddress, latitude, longitude);
+        when(hubService.register(any(Hub.class))).thenReturn(hubWithUuid);
+
+        HubRegistrationRequest request = new HubRegistrationRequest(sequence, name, city, fullAddress, latitude,
+                longitude);
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestBody = objectMapper.writeValueAsString(request);
+
+        given().contentType("application/json")
+            .body(requestBody)
+            .post("/api/v1/hubs")
+            .then()
+            .status(HttpStatus.OK)
+            .apply(document("허브 등록", requestPreprocessor(), responsePreprocessor(),
+                    requestFields(fieldWithPath("sequence").type(JsonFieldType.NUMBER).description("허브 순서"),
+                            fieldWithPath("name").type(JsonFieldType.STRING).description("허브명"),
+                            fieldWithPath("city").type(JsonFieldType.STRING).description("시도명"),
+                            fieldWithPath("fullAddress").type(JsonFieldType.STRING).description("전체 주소"),
+                            fieldWithPath("latitude").type(JsonFieldType.NUMBER).description("위도"),
+                            fieldWithPath("longitude").type(JsonFieldType.NUMBER).description("경도")),
+                    responseFields(fieldWithPath("result").type(JsonFieldType.STRING).description("결과"),
+                            fieldWithPath("data.hubUuid").type(JsonFieldType.STRING).description("허브 UUID"),
+                            fieldWithPath("error").type(JsonFieldType.NULL).ignored())));
+    }
+
+}

--- a/core/core-hub-domain/src/main/java/com/phoenix/logistics/core/hub/domain/Hub.java
+++ b/core/core-hub-domain/src/main/java/com/phoenix/logistics/core/hub/domain/Hub.java
@@ -1,0 +1,4 @@
+package com.phoenix.logistics.core.hub.domain;
+
+public record Hub(int sequence, String name, String city, String fullAddress, double latitude, double longitude) {
+}

--- a/core/core-hub-domain/src/main/java/com/phoenix/logistics/core/hub/domain/HubRegister.java
+++ b/core/core-hub-domain/src/main/java/com/phoenix/logistics/core/hub/domain/HubRegister.java
@@ -1,0 +1,20 @@
+package com.phoenix.logistics.core.hub.domain;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class HubRegister {
+
+    private final HubRepository hubRepository;
+
+    public HubRegister(HubRepository hubRepository) {
+        this.hubRepository = hubRepository;
+    }
+
+    @Transactional
+    public HubWithUuid register(Hub hub) {
+        return hubRepository.add(hub);
+    }
+
+}

--- a/core/core-hub-domain/src/main/java/com/phoenix/logistics/core/hub/domain/HubRepository.java
+++ b/core/core-hub-domain/src/main/java/com/phoenix/logistics/core/hub/domain/HubRepository.java
@@ -1,0 +1,10 @@
+package com.phoenix.logistics.core.hub.domain;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HubRepository {
+
+    HubWithUuid add(Hub hub);
+
+}

--- a/core/core-hub-domain/src/main/java/com/phoenix/logistics/core/hub/domain/HubService.java
+++ b/core/core-hub-domain/src/main/java/com/phoenix/logistics/core/hub/domain/HubService.java
@@ -1,0 +1,18 @@
+package com.phoenix.logistics.core.hub.domain;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class HubService {
+
+    private final HubRegister hubRegister;
+
+    public HubService(HubRegister hubRegister) {
+        this.hubRegister = hubRegister;
+    }
+
+    public HubWithUuid register(Hub hub) {
+        return hubRegister.register(hub);
+    }
+
+}

--- a/core/core-hub-domain/src/main/java/com/phoenix/logistics/core/hub/domain/HubWithUuid.java
+++ b/core/core-hub-domain/src/main/java/com/phoenix/logistics/core/hub/domain/HubWithUuid.java
@@ -1,0 +1,8 @@
+package com.phoenix.logistics.core.hub.domain;
+
+import java.util.UUID;
+
+public record HubWithUuid(UUID hubUuid, int sequence, String name, String city, String fullAddress, double latitude,
+        double longitude) {
+
+}

--- a/core/core-hub-domain/src/test/java/com/phoenix/logistics/core/hub/domain/HubRegisterTest.java
+++ b/core/core-hub-domain/src/test/java/com/phoenix/logistics/core/hub/domain/HubRegisterTest.java
@@ -1,0 +1,57 @@
+package com.phoenix.logistics.core.hub.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class HubRegisterTest {
+
+    @Mock
+    private HubRepository hubRepository;
+
+    private HubRegister hubRegister;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        hubRegister = new HubRegister(hubRepository);
+    }
+
+    @Test
+    void 허브를_등록한다() {
+        // given
+        int sequence = 1;
+        String name = "서울특별시 센터";
+        String city = "서울특별시";
+        String fullAddress = "서울특별시 송파구 송파대로 55";
+        double latitude = 37.4747005;
+        double longitude = 127.123397;
+        Hub hub = new Hub(sequence, name, city, fullAddress, latitude, longitude);
+
+        UUID hubUuid = UUID.randomUUID();
+        HubWithUuid hubWithUuid = new HubWithUuid(hubUuid, sequence, name, city, fullAddress, latitude, longitude);
+        when(hubRepository.add(hub)).thenReturn(hubWithUuid);
+
+        // when
+        HubWithUuid result = hubRegister.register(hub);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.hubUuid()).isEqualTo(hubUuid);
+        assertThat(result.sequence()).isEqualTo(sequence);
+        assertThat(result.name()).isEqualTo(name);
+        assertThat(result.city()).isEqualTo(city);
+        assertThat(result.fullAddress()).isEqualTo(fullAddress);
+        assertThat(result.latitude()).isEqualTo(latitude);
+        assertThat(result.longitude()).isEqualTo(longitude);
+    }
+
+}

--- a/core/core-hub-domain/src/test/java/com/phoenix/logistics/core/hub/domain/HubServiceTest.java
+++ b/core/core-hub-domain/src/test/java/com/phoenix/logistics/core/hub/domain/HubServiceTest.java
@@ -1,0 +1,57 @@
+package com.phoenix.logistics.core.hub.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class HubServiceTest {
+
+    @Mock
+    private HubRegister hubRegister;
+
+    private HubService hubService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        hubService = new HubService(hubRegister);
+    }
+
+    @Test
+    void 허브를_등록한다() {
+        // given
+        int sequence = 1;
+        String name = "서울특별시 센터";
+        String city = "서울특별시";
+        String fullAddress = "서울특별시 송파구 송파대로 55";
+        double latitude = 37.4747005;
+        double longitude = 127.123397;
+        Hub hub = new Hub(sequence, name, city, fullAddress, latitude, longitude);
+
+        UUID hubUuid = UUID.randomUUID();
+        HubWithUuid hubWithUuid = new HubWithUuid(hubUuid, sequence, name, city, fullAddress, latitude, longitude);
+        when(hubRegister.register(hub)).thenReturn(hubWithUuid);
+
+        // when
+        HubWithUuid result = hubService.register(hub);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.hubUuid()).isEqualTo(hubUuid);
+        assertThat(result.sequence()).isEqualTo(sequence);
+        assertThat(result.name()).isEqualTo(name);
+        assertThat(result.city()).isEqualTo(city);
+        assertThat(result.fullAddress()).isEqualTo(fullAddress);
+        assertThat(result.latitude()).isEqualTo(latitude);
+        assertThat(result.longitude()).isEqualTo(longitude);
+    }
+
+}

--- a/storage/db-core-hub/build.gradle
+++ b/storage/db-core-hub/build.gradle
@@ -9,4 +9,6 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    testImplementation project(":core:core-hub-domain")
 }

--- a/storage/db-core-hub/src/main/java/com/phoenix/logistics/storage/db/core/hub/HubCoreRepository.java
+++ b/storage/db-core-hub/src/main/java/com/phoenix/logistics/storage/db/core/hub/HubCoreRepository.java
@@ -1,0 +1,22 @@
+package com.phoenix.logistics.storage.db.core.hub;
+
+import com.phoenix.logistics.core.hub.domain.Hub;
+import com.phoenix.logistics.core.hub.domain.HubRepository;
+import com.phoenix.logistics.core.hub.domain.HubWithUuid;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class HubCoreRepository implements HubRepository {
+
+    private final HubJpaRepository hubJpaRepository;
+
+    public HubCoreRepository(HubJpaRepository hubJpaRepository) {
+        this.hubJpaRepository = hubJpaRepository;
+    }
+
+    @Override
+    public HubWithUuid add(Hub hub) {
+        return hubJpaRepository.save(HubEntity.of(hub)).toHubWithUuid();
+    }
+
+}

--- a/storage/db-core-hub/src/main/java/com/phoenix/logistics/storage/db/core/hub/HubEntity.java
+++ b/storage/db-core-hub/src/main/java/com/phoenix/logistics/storage/db/core/hub/HubEntity.java
@@ -1,5 +1,7 @@
 package com.phoenix.logistics.storage.db.core.hub;
 
+import com.phoenix.logistics.core.hub.domain.Hub;
+import com.phoenix.logistics.core.hub.domain.HubWithUuid;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -37,13 +39,23 @@ public class HubEntity extends BaseEntity {
     public HubEntity() {
     }
 
-    public HubEntity(int sequence, String name, String city, String fullAddress, double latitude, double longitude) {
+    HubEntity(int sequence, String name, String city, String fullAddress, double latitude, double longitude) {
         this.sequence = sequence;
         this.name = name;
         this.city = city;
         this.fullAddress = fullAddress;
         this.latitude = latitude;
         this.longitude = longitude;
+    }
+
+    public static HubEntity of(Hub hub) {
+        return new HubEntity(hub.sequence(), hub.name(), hub.city(), hub.fullAddress(), hub.latitude(),
+                hub.longitude());
+    }
+
+    public HubWithUuid toHubWithUuid() {
+        return new HubWithUuid(this.uuid, this.sequence, this.name, this.city, this.fullAddress, this.latitude,
+                this.longitude);
     }
 
     public UUID getUuid() {

--- a/storage/db-core-hub/src/main/java/com/phoenix/logistics/storage/db/core/hub/HubJpaRepository.java
+++ b/storage/db-core-hub/src/main/java/com/phoenix/logistics/storage/db/core/hub/HubJpaRepository.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface HubRepository extends JpaRepository<HubEntity, UUID> {
+public interface HubJpaRepository extends JpaRepository<HubEntity, UUID> {
 
     Optional<HubEntity> findByUuid(UUID uuid);
 

--- a/storage/db-core-hub/src/test/java/com/phoenix/logistics/storage/db/core/hub/HubCoreRepositoryIT.java
+++ b/storage/db-core-hub/src/test/java/com/phoenix/logistics/storage/db/core/hub/HubCoreRepositoryIT.java
@@ -1,0 +1,44 @@
+package com.phoenix.logistics.storage.db.core.hub;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.phoenix.logistics.core.hub.domain.Hub;
+import com.phoenix.logistics.core.hub.domain.HubWithUuid;
+import com.phoenix.logistics.storage.db.CoreDbContextTest;
+import org.junit.jupiter.api.Test;
+
+class HubCoreRepositoryIT extends CoreDbContextTest {
+
+    private final HubCoreRepository hubCoreRepository;
+
+    public HubCoreRepositoryIT(HubCoreRepository hubCoreRepository) {
+        this.hubCoreRepository = hubCoreRepository;
+    }
+
+    @Test
+    void 허브가_정상적으로_추가돼야_한다() {
+        // given
+        int sequence = 1;
+        String name = "서울특별시 센터";
+        String city = "서울특별시";
+        String fullAddress = "서울특별시 송파구 송파대로 55";
+        double latitude = 37.4747005;
+        double longitude = 127.123397;
+
+        Hub hub = new Hub(sequence, name, city, fullAddress, latitude, longitude);
+
+        // when
+        HubWithUuid result = hubCoreRepository.add(hub);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.hubUuid()).isNotNull();
+        assertThat(result.sequence()).isEqualTo(sequence);
+        assertThat(result.name()).isEqualTo(name);
+        assertThat(result.city()).isEqualTo(city);
+        assertThat(result.fullAddress()).isEqualTo(fullAddress);
+        assertThat(result.latitude()).isEqualTo(latitude);
+        assertThat(result.longitude()).isEqualTo(longitude);
+    }
+
+}

--- a/storage/db-core-hub/src/test/java/com/phoenix/logistics/storage/db/core/hub/HubJpaRepositoryIT.java
+++ b/storage/db-core-hub/src/test/java/com/phoenix/logistics/storage/db/core/hub/HubJpaRepositoryIT.java
@@ -5,12 +5,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.phoenix.logistics.storage.db.CoreDbContextTest;
 import org.junit.jupiter.api.Test;
 
-class HubRepositoryIT extends CoreDbContextTest {
+class HubJpaRepositoryIT extends CoreDbContextTest {
 
-    private final HubRepository hubRepository;
+    private final HubJpaRepository hubJpaRepository;
 
-    public HubRepositoryIT(HubRepository hubRepository) {
-        this.hubRepository = hubRepository;
+    public HubJpaRepositoryIT(HubJpaRepository hubJpaRepository) {
+        this.hubJpaRepository = hubJpaRepository;
     }
 
     @Test
@@ -22,10 +22,11 @@ class HubRepositoryIT extends CoreDbContextTest {
         String fullAddress = "서울특별시 송파구 송파대로 55";
         double latitude = 37.4747005;
         double longitude = 127.123397;
-        HubEntity hub = hubRepository.save(new HubEntity(sequence, name, city, fullAddress, latitude, longitude));
+
+        HubEntity hub = hubJpaRepository.save(new HubEntity(sequence, name, city, fullAddress, latitude, longitude));
 
         // when
-        HubEntity addedHub = hubRepository.findByUuid(hub.getUuid())
+        HubEntity addedHub = hubJpaRepository.findByUuid(hub.getUuid())
             .orElseThrow(() -> new AssertionError("Hub not found"));
 
         // then


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 관련 이슈가 있다면 여기에 링크해주세요. 예: Closes #123, Related to #456 -->
- Closes #13

## 📌 PR 요약

<!-- 이 PR의 목적과 주요 변경 사항을 간단히 설명해주세요 -->
- 허브 등록 API 구현

## 🔍 주요 변경 사항

<!-- bullet point로 주요 변경 사항을 나열해주세요 -->
- 도메인 모듈에 레포지토리 추상화 인터페이스 추가
- 스토리지 모듈에 추상화 인터페이스를 구현한 실제 구현 레포지토리 클래스 추가
- 구현, 비즈니스 레이어 계층으로 비즈니스 로직 구분
  - `HubRegister.class`, `HubService.class` 
- 허브 등록 컨트롤러 구현

## 🧪 테스트 방법

<!-- 이 변경 사항을 어떻게 테스트할 수 있는지 간단히 설명해주세요 -->
```bash
./gradlew test
```

```bash
./gradlew restDocsTest
```

## ✅ PR 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 필요한 테스트를 추가하고 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요? (필요한 경우)
  - [허브 등록 API 문서](https://www.notion.so/teamsparta/API-fc398555d8204196a64ef517c90624df?p=621afe2c8ee543dfbbb5d14a9919e8cf&pm=s)
  - `core-hub-api/src/docs/asciidoc/index.adoc`

## 👀 리뷰어 체크 포인트

<!-- 리뷰어가 특별히 확인해야 할 부분이 있다면 언급해주세요 -->
- 엔티티 생성 날짜가 API 응답에 `null`로 담겼던 이슈 관련 
  - 허브 등록 비즈니스 로직 메서드에 트랜잭션을 걸고, 추가 조회 로직 없이 트랜잭션 내에서 영속성 컨텍스트에 저장된 캐시를 그대로 반환했기 때문에 실제 데이터베이스에 반영되기 전 영속성 컨텍스트에 저장된 엔티티를 조회해서 실제 데이터베이스에 삽입 시점에 생성되는 날짜 컬럼이 존재하지 않아 `null` 값을 반환했습니다.
  - 해결
    - 트랜잭션을 걸지 않고 즉시 데이터베이스에 반영한다
      - 데이터 일관성을 위해 트랜잭션을 걸고 싶기 때문에 기각 ❌
    - 저장 후 추가적인 조회 쿼리 실행
      - 쿼리를 한 번 더 날리고 싶지 않아 기각 ❌
    - 등록 API 응답에 굳이 날짜 필드가 필요한가?
      - 조회 API 응답에 날짜 필드를 필수로 하고, 등록 응답 스펙에 날짜 필드는 굳이 필요할 것 같지 않아 날짜 필드 삭제로 이슈 해결 ✅

## 💬 기타 코멘트

<!-- 추가로 공유할 내용이 있다면 여기에 적어주세요 -->
- PR 다이어트 실패 죄송합니다😭